### PR TITLE
Remove references to color formatting

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ Spicy::Proton.adjective             # => "extreme"
 Spicy::Proton.noun                  # => "loan"
 Spicy::Proton.pair                  # => "opportune-spacesuit"
 Spicy::Proton.pair(':')             # => "hip:squash"
-Spicy::Proton.format('%a/%c/%n')    # => "slippery/ultramarine/rattler"
+Spicy::Proton.format('%a/%n')       # => "slippery/rattler"
 
 # With length constraints.
 Spicy::Proton.noun(min: 10)         # => "translucence"

--- a/lib/spicy-proton.rb
+++ b/lib/spicy-proton.rb
@@ -43,7 +43,7 @@ module Spicy
     private
 
     def self.format_with(source, format)
-      format.gsub(/%([anc%])/) do
+      format.gsub(/%([an%])/) do
         case $1
         when 'a'
           source.adjective


### PR DESCRIPTION
Noticed this on Ruby Weekly, and the color thing caught my attention.  :)