### PR TITLE
Remove another possible NSFW word from adjectives list

### DIFF
--- a/corpus/adjectives.txt
+++ b/corpus/adjectives.txt
@@ -998,7 +998,6 @@ moslem
 motive
 motley
 moving
-muslim
 mutual
 myopic
 myriad


### PR DESCRIPTION
This commit is a follow-up to the previous NSFW-removal commit, it
removes a religious word from `adjectives.txt`