### PR TITLE
Remove 'overweight'

### DIFF
--- a/corpus/adjectives.txt
+++ b/corpus/adjectives.txt
@@ -3658,7 +3658,6 @@ orthopedic
 ostensible
 outlandish
 overactive
-overweight
 pacifistic
 palliative
 pantomimic

--- a/corpus/nouns.txt
+++ b/corpus/nouns.txt
@@ -8888,7 +8888,6 @@ outfielder
 outpatient
 outpouring
 overriding
-overweight
 paintbrush
 panjandrum
 paramagnet


### PR DESCRIPTION
This commit removes the word 'overweight' from the corpus. This is an
insensitive term that implies that there is a certain weight that one _should_
be, rather than 'over' or 'under'.