### PR TITLE
Remove the word 'booby' from nouns

### DIFF
--- a/corpus/nouns.txt
+++ b/corpus/nouns.txt
@@ -1350,7 +1350,6 @@ boast
 bobby
 bogey
 bongo
-booby
 boost
 booth
 booty


### PR DESCRIPTION
Personally I don't think the word 'booby' is appropriate for this library. I just added this gem to my app and was taking it for a spin; I got the pair "sized booby" which I thought was rather 😬 

What do you reckon?