### PR TITLE
Remove sensitive noun from corpus

### DIFF
--- a/corpus/nouns.txt
+++ b/corpus/nouns.txt
@@ -5175,7 +5175,6 @@ subsidy
 subsoil
 subtype
 suction
-suicide
 sulfide
 sulphur
 summary


### PR DESCRIPTION
This is probably a word a person wouldn't want to see unexpectedly if it relates to themselves or people they know.